### PR TITLE
Add `--remote` option (default: origin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 
+* New argument `--remote` to specify remote (default: 'origin')
+
 ### Changed
 
 ### Deprecated

--- a/exe/keepachangelog_manager.rb
+++ b/exe/keepachangelog_manager.rb
@@ -7,7 +7,9 @@ $exit_code = 0
 # Use some basic parsing to allow command-line overrides of config
 class Parser
   def self.parse(options)
-    parsed_config = {}
+    parsed_config = {
+      remote: 'origin',
+    }
 
     opt_parser = OptionParser.new do |opts|
       opts.banner = "Usage: #{File.basename(__FILE__)} <ONLY ONE of the following options>"
@@ -36,6 +38,10 @@ class Parser
         parsed_config[:inc_patch] = v
       end
 
+      opts.on("--remote=REMOTE", "Use git remote REMOTE (default: 'origin')") do |r|
+        parsed_config[:remote] = r
+      end
+
       opts.on("-h", "--help", "Prints this help") do
         puts opts
         exit $exit_code
@@ -54,6 +60,6 @@ if @cli_options.empty?
   Parser.parse %w[--help]
 end
 
-repo = KeepAChangelogManager::Repo.new(`git rev-parse --show-toplevel`.strip)
-new_version = repo.changelog.update(@cli_options)
+repo = KeepAChangelogManager::Repo.new(`git rev-parse --show-toplevel`.strip, @cli_options[:remote])
+new_version = repo.changelog.update(@cli_options.reject { |k, _v| k == :remote })
 puts new_version

--- a/lib/keepachangelog_manager/repo.rb
+++ b/lib/keepachangelog_manager/repo.rb
@@ -12,8 +12,9 @@ module KeepAChangelogManager
     # Create a new Repo representing git repository, given its path
     #
     # @param root String path to root directory of repository
-    def initialize(root)
+    def initialize(root, remote = 'origin')
       @root = root
+      @remote = remote
     end
 
     # Get the repository name.  It is assumed to be the name of the repo root directory
@@ -30,7 +31,7 @@ module KeepAChangelogManager
     #
     # @return String
     def origin_url
-      `git remote get-url origin`
+      `git remote -v`.lines.grep(/^#{@remote}\b/).first.split(/\s+/)[1]
     end
 
     # Extract the owner from a git URL


### PR DESCRIPTION
This patch adds a `--remote` option for repos that use a remote other than `origin`